### PR TITLE
update dfuzzer.conf

### DIFF
--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -1,17 +1,31 @@
 [org.freedesktop.login1]
-TerminateSession destructive
-ReleaseSession destructive
-LockSession destructive
-TerminateUser destructive
-Suspend destructive
-Reboot destructive
-PowerOff destructive
-HybridSleep destructive
-KillUser destructive
-KillSession destructive
-LockSession destructive
+Halt destructive
+HaltWithFlags destructive
 Hibernate destructive
+HibernateWithFlags destructive
+HybridSleep destructive
+HybridSleepWithFlags destructive
+KillSession destructive
+KillUser destructive
+LockSession destructive
+LockSessions destructive
+PowerOff destructive
+PowerOffWithFlags destructive
+Reboot destructive
+RebootWithFlags destructive
+ReleaseSession destructive
+ScheduleShutdown destructive
+Suspend destructive
+SuspendThenHibernate destructive
+SuspendThenHibernateWithFlags destructive
+SuspendWithFlags destructive
 TerminateSeat destructive
+TerminateSession destructive
+TerminateUser destructive
+
+[org.freedesktop.timedate1]
+SetLocalRTC destructive method breaking the RTC and system time
+SetNTP destructive method turning off systemd-timesyncd
 
 [org.freedesktop.NetworkManager]
 Enable destructive


### PR DESCRIPTION
to make it easier to test systemd outside of VMs spun up by
the systemd testsuite. Unfortunately it's hard to set up Valgrind
and MSan there.

It was borrowed from https://github.com/systemd/systemd/pull/22547.

@mrc0mmand could you take a look?